### PR TITLE
refactor: change the packageName to packagename

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project is a template reference for hexagonal spring boot. This repository 
 
 The keywords of the app-generators are the following
 
-- `packageName` - to rename the package names
+- `packagename` - to rename the package names
 - `artifactName` - to rename the artifact id
 - `Example` - to rename class, variables 
 

--- a/acceptance-test/src/test/kotlin/packageName/AcceptanceTest.kt
+++ b/acceptance-test/src/test/kotlin/packageName/AcceptanceTest.kt
@@ -1,4 +1,4 @@
-package packageName
+package packagename
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -8,9 +8,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
-import packageName.domain.ExampleDomain
-import packageName.domain.model.Example
-import packageName.domain.port.ObtainExample
+import packagename.domain.ExampleDomain
+import packagename.domain.model.Example
+import packagename.domain.port.ObtainExample
 
 @ExtendWith(MockitoExtension::class)
 @RunWith(JUnitPlatform::class)

--- a/acceptance-test/src/test/kotlin/packageName/ExampleE2EApplication.kt
+++ b/acceptance-test/src/test/kotlin/packageName/ExampleE2EApplication.kt
@@ -1,14 +1,14 @@
-package packageName
+package packagename
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
-import packageName.domain.ExampleDomain
-import packageName.domain.port.ObtainExample
-import packageName.domain.port.RequestExample
-import packageName.repository.config.JpaAdapterConfig
+import packagename.domain.ExampleDomain
+import packagename.domain.port.ObtainExample
+import packagename.domain.port.RequestExample
+import packagename.repository.config.JpaAdapterConfig
 
 @SpringBootApplication
 class ExampleE2EApplication {

--- a/acceptance-test/src/test/kotlin/packageName/cucumber/ExampleStepDef.kt
+++ b/acceptance-test/src/test/kotlin/packageName/cucumber/ExampleStepDef.kt
@@ -1,4 +1,4 @@
-package packageName.cucumber
+package packagename.cucumber
 
 import io.cucumber.datatable.DataTable
 import io.cucumber.java8.En
@@ -14,11 +14,11 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import packageName.ExampleE2EApplication
-import packageName.domain.model.Example
-import packageName.domain.model.ExampleInfo
-import packageName.repository.dao.ExampleDao
-import packageName.repository.entity.ExampleEntity
+import packagename.ExampleE2EApplication
+import packagename.domain.model.Example
+import packagename.domain.model.ExampleInfo
+import packagename.repository.dao.ExampleDao
+import packagename.repository.entity.ExampleEntity
 
 
 @ExtendWith(SpringExtension::class)

--- a/acceptance-test/src/test/kotlin/packageName/cucumber/RunCucumberExampleTest.kt
+++ b/acceptance-test/src/test/kotlin/packageName/cucumber/RunCucumberExampleTest.kt
@@ -1,9 +1,9 @@
-package packageName.cucumber
+package packagename.cucumber
 
 import io.cucumber.junit.Cucumber
 import io.cucumber.junit.CucumberOptions
 import org.junit.runner.RunWith
 
 @RunWith(Cucumber::class)
-@CucumberOptions(features = ["classpath:features"], strict = true, plugin = ["json:target/cucumber/example.json", "json:target/cucumber/example.xml"], tags = ["@Example"], glue = ["classpath:packageName.cucumber"])
+@CucumberOptions(features = ["classpath:features"], strict = true, plugin = ["json:target/cucumber/example.json", "json:target/cucumber/example.xml"], tags = ["@Example"], glue = ["classpath:packagename.cucumber"])
 class RunCucumberExampleTest

--- a/bootstrap/src/main/kotlin/packageName/boot/ExampleApplication.kt
+++ b/bootstrap/src/main/kotlin/packageName/boot/ExampleApplication.kt
@@ -1,11 +1,11 @@
-package packageName.boot
+package packagename.boot
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.ComponentScan
 
 @SpringBootApplication
-@ComponentScan(basePackages = ["packageName"])
+@ComponentScan(basePackages = ["packagename"])
 class ExampleApplication {
 }
 

--- a/bootstrap/src/main/kotlin/packageName/boot/config/BootstrapConfig.kt
+++ b/bootstrap/src/main/kotlin/packageName/boot/config/BootstrapConfig.kt
@@ -1,12 +1,12 @@
-package packageName.boot.config
+package packagename.boot.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import packageName.domain.ExampleDomain
-import packageName.domain.port.ObtainExample
-import packageName.domain.port.RequestExample
-import packageName.repository.config.JpaAdapterConfig
+import packagename.domain.ExampleDomain
+import packagename.domain.port.ObtainExample
+import packagename.domain.port.RequestExample
+import packagename.repository.config.JpaAdapterConfig
 
 @Configuration
 @Import(JpaAdapterConfig::class)

--- a/domain-api/src/main/kotlin/packageName/domain/exception/ExampleNotFoundException.kt
+++ b/domain-api/src/main/kotlin/packageName/domain/exception/ExampleNotFoundException.kt
@@ -1,4 +1,4 @@
-package packageName.domain.exception
+package packagename.domain.exception
 
 class ExampleNotFoundException : RuntimeException()
 

--- a/domain-api/src/main/kotlin/packageName/domain/model/Example.kt
+++ b/domain-api/src/main/kotlin/packageName/domain/model/Example.kt
@@ -1,3 +1,3 @@
-package packageName.domain.model
+package packagename.domain.model
 
 data class Example(val id: Long? = null, val description: String)

--- a/domain-api/src/main/kotlin/packageName/domain/model/ExampleInfo.kt
+++ b/domain-api/src/main/kotlin/packageName/domain/model/ExampleInfo.kt
@@ -1,3 +1,3 @@
-package packageName.domain.model
+package packagename.domain.model
 
 data class ExampleInfo(val examples: List<Example>)

--- a/domain-api/src/main/kotlin/packageName/domain/port/ObtainExample.kt
+++ b/domain-api/src/main/kotlin/packageName/domain/port/ObtainExample.kt
@@ -1,6 +1,6 @@
-package packageName.domain.port
+package packagename.domain.port
 
-import packageName.domain.model.Example
+import packagename.domain.model.Example
 
 interface ObtainExample {
 

--- a/domain-api/src/main/kotlin/packageName/domain/port/RequestExample.kt
+++ b/domain-api/src/main/kotlin/packageName/domain/port/RequestExample.kt
@@ -1,6 +1,6 @@
-package packageName.domain.port
+package packagename.domain.port
 
-import packageName.domain.model.ExampleInfo
+import packagename.domain.model.ExampleInfo
 
 interface RequestExample {
   fun getExamples(): ExampleInfo

--- a/domain/src/main/kotlin/packageName/domain/ExampleDomain.kt
+++ b/domain/src/main/kotlin/packageName/domain/ExampleDomain.kt
@@ -1,8 +1,8 @@
-package packageName.domain
+package packagename.domain
 
-import packageName.domain.model.ExampleInfo
-import packageName.domain.port.ObtainExample
-import packageName.domain.port.RequestExample
+import packagename.domain.model.ExampleInfo
+import packagename.domain.port.ObtainExample
+import packagename.domain.port.RequestExample
 
 class ExampleDomain(private val obtainExample: ObtainExample) : RequestExample {
 

--- a/jpa-adapter/src/main/kotlin/packageName/repository/ExampleRepository.kt
+++ b/jpa-adapter/src/main/kotlin/packageName/repository/ExampleRepository.kt
@@ -1,8 +1,8 @@
-package packageName.repository
+package packagename.repository
 
-import packageName.domain.model.Example
-import packageName.domain.port.ObtainExample
-import packageName.repository.dao.ExampleDao
+import packagename.domain.model.Example
+import packagename.domain.port.ObtainExample
+import packagename.repository.dao.ExampleDao
 
 class ExampleRepository(private val exampleDao: ExampleDao) : ObtainExample {
 

--- a/jpa-adapter/src/main/kotlin/packageName/repository/config/JpaAdapterConfig.kt
+++ b/jpa-adapter/src/main/kotlin/packageName/repository/config/JpaAdapterConfig.kt
@@ -1,16 +1,16 @@
-package packageName.repository.config
+package packagename.repository.config
 
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
-import packageName.domain.port.ObtainExample
-import packageName.repository.ExampleRepository
-import packageName.repository.dao.ExampleDao
+import packagename.domain.port.ObtainExample
+import packagename.repository.ExampleRepository
+import packagename.repository.dao.ExampleDao
 
 @Configuration
-@EntityScan("packageName.repository.entity")
-@EnableJpaRepositories("packageName.repository.dao")
+@EntityScan("packagename.repository.entity")
+@EnableJpaRepositories("packagename.repository.dao")
 class JpaAdapterConfig {
 
   @Bean

--- a/jpa-adapter/src/main/kotlin/packageName/repository/dao/ExampleDao.kt
+++ b/jpa-adapter/src/main/kotlin/packageName/repository/dao/ExampleDao.kt
@@ -1,8 +1,8 @@
-package packageName.repository.dao
+package packagename.repository.dao
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import packageName.repository.entity.ExampleEntity
+import packagename.repository.entity.ExampleEntity
 
 @Repository
 interface ExampleDao : JpaRepository<ExampleEntity, Long>

--- a/jpa-adapter/src/main/kotlin/packageName/repository/entity/ExampleEntity.kt
+++ b/jpa-adapter/src/main/kotlin/packageName/repository/entity/ExampleEntity.kt
@@ -1,6 +1,6 @@
-package packageName.repository.entity
+package packagename.repository.entity
 
-import packageName.domain.model.Example
+import packagename.domain.model.Example
 import javax.persistence.*
 import javax.persistence.GenerationType.AUTO
 

--- a/jpa-adapter/src/test/kotlin/packageName/repository/ExampleJpaAdapterApplication.kt
+++ b/jpa-adapter/src/test/kotlin/packageName/repository/ExampleJpaAdapterApplication.kt
@@ -1,11 +1,11 @@
-package packageName.repository
+package packagename.repository
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import packageName.domain.port.ObtainExample
-import packageName.repository.dao.ExampleDao
+import packagename.domain.port.ObtainExample
+import packagename.repository.dao.ExampleDao
 
 @SpringBootApplication
 class ExampleJpaAdapterApplication {

--- a/jpa-adapter/src/test/kotlin/packageName/repository/ExampleJpaTest.kt
+++ b/jpa-adapter/src/test/kotlin/packageName/repository/ExampleJpaTest.kt
@@ -1,4 +1,4 @@
-package packageName.repository
+package packagename.repository
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import packageName.domain.port.ObtainExample
+import packagename.domain.port.ObtainExample
 
 @ExtendWith(SpringExtension::class)
 @DataJpaTest

--- a/rest-adapter/src/main/kotlin/packageName/rest/ExampleResource.kt
+++ b/rest-adapter/src/main/kotlin/packageName/rest/ExampleResource.kt
@@ -1,11 +1,11 @@
-package packageName.rest
+package packagename.rest
 
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import packageName.domain.model.ExampleInfo
-import packageName.domain.port.RequestExample
+import packagename.domain.model.ExampleInfo
+import packagename.domain.port.RequestExample
 
 @RestController
 @RequestMapping("/api/v1/examples")

--- a/rest-adapter/src/main/kotlin/packageName/rest/exception/ExampleExceptionHandler.kt
+++ b/rest-adapter/src/main/kotlin/packageName/rest/exception/ExampleExceptionHandler.kt
@@ -1,4 +1,4 @@
-package packageName.rest.exception
+package packagename.rest.exception
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -6,9 +6,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
-import packageName.domain.exception.ExampleNotFoundException
+import packagename.domain.exception.ExampleNotFoundException
 
-@RestControllerAdvice(basePackages = ["packageName"])
+@RestControllerAdvice(basePackages = ["packagename"])
 class ExampleExceptionHandler {
 
   @ExceptionHandler(value = [ExampleNotFoundException::class])

--- a/rest-adapter/src/main/kotlin/packageName/rest/exception/ExampleExceptionResponse.kt
+++ b/rest-adapter/src/main/kotlin/packageName/rest/exception/ExampleExceptionResponse.kt
@@ -1,3 +1,3 @@
-package packageName.rest.exception
+package packagename.rest.exception
 
 data class ExampleExceptionResponse(val message: String, val path: String)

--- a/rest-adapter/src/test/kotlin/packageName/rest/ExamplePoetryRestAdapterApplication.kt
+++ b/rest-adapter/src/test/kotlin/packageName/rest/ExamplePoetryRestAdapterApplication.kt
@@ -1,13 +1,13 @@
-package packageName.rest
+package packagename.rest
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.ComponentScan
-import packageName.domain.port.RequestExample
+import packagename.domain.port.RequestExample
 
 @SpringBootApplication
-@ComponentScan(basePackages = ["packageName"])
+@ComponentScan(basePackages = ["packagename"])
 class ExamplePoetryRestAdapterApplication {
 
   @MockBean

--- a/rest-adapter/src/test/kotlin/packageName/rest/ExampleResourceTest.kt
+++ b/rest-adapter/src/test/kotlin/packageName/rest/ExampleResourceTest.kt
@@ -1,4 +1,4 @@
-package packageName.rest
+package packagename.rest
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -13,9 +13,9 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.http.HttpStatus
-import packageName.domain.model.Example
-import packageName.domain.model.ExampleInfo
-import packageName.domain.port.RequestExample
+import packagename.domain.model.Example
+import packagename.domain.model.ExampleInfo
+import packagename.domain.port.RequestExample
 
 @ExtendWith(MockitoExtension::class)
 @SpringBootTest(classes = [ExamplePoetryRestAdapterApplication::class], webEnvironment = RANDOM_PORT)


### PR DESCRIPTION
# Description
When we have `packageName' as the name of a package then its not a java standard because it should essentially be all lower case however we have used camelCase.

<!-- Description about this pull request -->

Closes : <!-- refer the github issue. Ex: #084-->
https://github.com/devs-from-matrix/hexagonal-spring-boot-kotlin/issues/15

# Checklist:

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
