### PR TITLE
build: bump versions to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use it with caution as these will be used by the app-generator to replace them w
 
 This project uses [git-code-format-maven-plugin](https://github.com/Cosium/git-code-format-maven-plugin) for formatting the code per [google style guide](https://google.github.io/styleguide/javaguide.html)
 
-> **`mvn git-code-format:format-code`**
+`mvn git-code-format:format-code`
 
 ## Contribution guidelines
 

--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -9,6 +9,9 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>acceptance-test</artifactId>
+  <properties>
+    <io.cucumber-message.version>17.1.1</io.cucumber-message.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.dfm</groupId>
@@ -31,6 +34,17 @@
       <artifactId>cucumber-java8</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.cucumber</groupId>
+          <artifactId>messages</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>messages</artifactId>
+      <version>${io.cucumber-message.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>

--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -31,36 +31,18 @@
       <artifactId>cucumber-java8</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>apiguardian-api</artifactId>
-          <groupId>org.apiguardian</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
-      <artifactId>cucumber-junit</artifactId>
+      <artifactId>cucumber-junit-platform-engine</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>apiguardian-api</artifactId>
-          <groupId>org.apiguardian</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-spring</artifactId>
       <version>${cucumber.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>apiguardian-api</artifactId>
-          <groupId>org.apiguardian</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/acceptance-test/src/test/kotlin/packagename/AcceptanceTest.kt
+++ b/acceptance-test/src/test/kotlin/packagename/AcceptanceTest.kt
@@ -4,8 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
@@ -16,7 +14,6 @@ import packagename.domain.port.ObtainExample
 import java.util.*
 
 @ExtendWith(MockitoExtension::class)
-@RunWith(JUnitPlatform::class)
 class AcceptanceTest {
 
   @Test

--- a/acceptance-test/src/test/kotlin/packagename/cucumber/ExampleStepDef.kt
+++ b/acceptance-test/src/test/kotlin/packagename/cucumber/ExampleStepDef.kt
@@ -21,10 +21,6 @@ import packagename.repository.entity.ExampleEntity
 import packagename.rest.exception.ExampleExceptionResponse
 
 
-@ExtendWith(SpringExtension::class)
-@SpringBootTest(classes = [ExampleApplication::class], webEnvironment = RANDOM_PORT)
-@CucumberContextConfiguration
-@ActiveProfiles("test")
 class ExampleStepDef(restTemplate: TestRestTemplate, exampleDao: ExampleDao) : En {
 
   companion object {

--- a/acceptance-test/src/test/kotlin/packagename/cucumber/RunCucumberExampleTest.kt
+++ b/acceptance-test/src/test/kotlin/packagename/cucumber/RunCucumberExampleTest.kt
@@ -1,13 +1,16 @@
 package packagename.cucumber
 
-import io.cucumber.junit.Cucumber
-import io.cucumber.junit.CucumberOptions
-import org.junit.runner.RunWith
+import io.cucumber.junit.platform.engine.Constants.*
+import org.junit.platform.suite.api.*
 
-@RunWith(Cucumber::class)
-@CucumberOptions(features = ["classpath:features/example.feature"],
-    strict = true,
-    plugin = ["json:target/cucumber/example.json", "json:target/cucumber/example.xml"],
-    tags = "@Example",
-    glue = ["classpath:packagename.cucumber"])
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features/example.feature")
+@ConfigurationParameters(
+    ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "packagename.cucumber"),
+    ConfigurationParameter(key = FILTER_TAGS_PROPERTY_NAME, value = "@Example"),
+    ConfigurationParameter(key = JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, value = "long"),
+    ConfigurationParameter(key = PLUGIN_PUBLISH_QUIET_PROPERTY_NAME, value = "true"),
+    ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber/cucumber.json")
+)
 class RunCucumberExampleTest

--- a/acceptance-test/src/test/kotlin/packagename/cucumber/SpringCucumberTestConfig.kt
+++ b/acceptance-test/src/test/kotlin/packagename/cucumber/SpringCucumberTestConfig.kt
@@ -1,0 +1,11 @@
+package packagename.cucumber
+
+import io.cucumber.spring.CucumberContextConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import packagename.boot.ExampleApplication
+
+@SpringBootTest(classes = [ExampleApplication::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@CucumberContextConfiguration
+@ActiveProfiles("test")
+class SpringCucumberTestConfig

--- a/jpa-adapter/pom.xml
+++ b/jpa-adapter/pom.xml
@@ -19,6 +19,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.roo</groupId>
+          <artifactId>org.springframework.roo.annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>
@@ -27,6 +33,20 @@
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-envers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.roo</groupId>
+          <artifactId>org.springframework.roo.annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.lbruun.springboot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <!-- plugins -->
     <cukedoctor-maven-plugin.version>3.7.0</cukedoctor-maven-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <maven-enforcer-plugin>3.0.0-M3</maven-enforcer-plugin>
+    <maven-enforcer-plugin>3.0.0</maven-enforcer-plugin>
     <arch-unit-maven-plugin.version>2.8.0</arch-unit-maven-plugin.version>
     <jackson-module-kotlin.version>2.13.0</jackson-module-kotlin.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,9 @@
     <kotlin.version>1.5.31</kotlin.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
+    <junit-jupiter.version>5.8.1</junit-jupiter.version>
     <spring-boot.version>2.5.6</spring-boot.version>
-    <cucumber.version>6.11.0</cucumber.version>
+    <cucumber.version>7.0.0</cucumber.version>
     <springdoc.version>1.5.12</springdoc.version>
     <pre-liquibase.version>1.1.1</pre-liquibase.version>
     <!-- plugins -->
@@ -82,6 +83,13 @@
       </dependency>
       <!-- Frameworks & Libraries -->
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit-jupiter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
@@ -111,27 +119,12 @@
     <!-- JUnit 5 dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
+      <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- mockito dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
     <kotlin.version>1.5.31</kotlin.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spring-boot.version>2.5.5</spring-boot.version>
+    <spring-boot.version>2.5.6</spring-boot.version>
     <cucumber.version>6.11.0</cucumber.version>
-    <springdoc.version>1.5.11</springdoc.version>
+    <springdoc.version>1.5.12</springdoc.version>
     <pre-liquibase.version>1.1.1</pre-liquibase.version>
     <!-- plugins -->
     <cukedoctor-maven-plugin.version>3.7.0</cukedoctor-maven-plugin.version>


### PR DESCRIPTION
# Description

- Spring-boot: 2.5.6
- Springdoc: 1.5.12
- cucumber: 7.0.0
- maven-enforcer-plugin: 3.0.0
- junit bom: 5.8.1

## Breaking changes while upgrading

### Cucumber: `7.0.0`

Lambda's (cucumber-java8) does not work well with the `CucumberContextConfiguration` in the same file. Hence had to extract it to a different class from the StepDef as suggested in as suggested in cucumber/cucumber-jvm#2413

### maven-enforcer-plugin: `3.0.0`

This is an issue with legacy `org.springframework.roo.annotations` dependency as mentioned in https://github.com/spring-projects/spring-data-jpa/issues/2285 which refers to a repository which is not actually present in maven central but at https://spring-roo-repository.springsource.org/release. Since the resource of this dependency is not used this template we can as well exclude it as mentioned in https://github.com/spring-projects/spring-data-jpa/issues/2347


```xml
<dependency>
  <groupId>org.springframework.boot</groupId>
  <artifactId>spring-boot-starter-data-jpa</artifactId>
  <exclusions>
    <exclusion>
      <groupId>org.springframework.roo</groupId>
      <artifactId>org.springframework.roo.annotations</artifactId>
    </exclusion>
  </exclusions>
</dependency>
<dependency>
  <groupId>org.springframework.data</groupId>
  <artifactId>spring-data-envers</artifactId>
  <exclusions>
    <exclusion>
      <groupId>org.springframework.roo</groupId>
      <artifactId>org.springframework.roo.annotations</artifactId>
    </exclusion>
  </exclusions>
</dependency>
```

# Checklist:

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow [conventional commit message guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
